### PR TITLE
Run tests on PHP 8.5 too

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,6 +13,7 @@ jobs:
           - "8.2"
           - "8.3"
           - "8.4"
+          - "8.5"
 
     steps:
     - uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"psr-4": {"Spaze\\NonceGenerator\\": "src"}
 	},
 	"require-dev": {
-		"nette/tester": "^2.5",
+		"nette/tester": "^2.5.7",
 		"phpstan/phpstan": "^2.1",
 		"spaze/coding-standard": "^1.8",
 		"php-parallel-lint/php-parallel-lint": "^1.4",


### PR DESCRIPTION
Require Tester with PHP 8.5 support, otherwise `--prefer-lowest` tests would fail on 8.5, but tests are not yet run with `--prefer-lowest`.